### PR TITLE
Allow use of endpoint_url and list objects from a prefix

### DIFF
--- a/bucketstore.py
+++ b/bucketstore.py
@@ -191,10 +191,11 @@ class S3Bucket:
             else:
                 paginator = self._boto_s3.meta.client.get_paginator('list_objects_v2')
             objects = []
-            for page in paginator.paginate(Bucket=self.name, Delimiter="/", Prefix=prefix):
-                for obj in page['Contents']:
-                    objects += obj.key
+            for page in paginator.paginate(Bucket=self.name, Prefix=prefix):
+                for obj in page.get('Contents', []):
+                    objects.append(obj['Key'])
             return objects
+        
         return [k.key for k in self._boto_bucket.objects.all()]
 
     @property

--- a/bucketstore.py
+++ b/bucketstore.py
@@ -183,10 +183,15 @@ class S3Bucket:
                 return False
             raise  # pragma: no cover
 
-    def list(self, prefix: str = None) -> List:
+    def list(self, prefix: str = None, legacy_api: bool = False) -> List:
         """returns a list of keys in the bucket."""
         if prefix:
-            [k.key for k in self._boto_bucket.objects.filter(Delimiter="/", Prefix=prefix)]
+            if legacy_api:
+                paginator = self._boto_s3.get_paginator('list_objects')
+            else:
+                paginator = self._boto_s3.get_paginator('list_objects_v2')
+                
+            [k.key for k in paginator.paginate(Bucket=self.name, Delimiter="/", Prefix=prefix)['Contents']]
         return [k.key for k in self._boto_bucket.objects.all()]
 
     @property

--- a/bucketstore.py
+++ b/bucketstore.py
@@ -190,8 +190,11 @@ class S3Bucket:
                 paginator = self._boto_s3.meta.client.get_paginator('list_objects')
             else:
                 paginator = self._boto_s3.meta.client.get_paginator('list_objects_v2')
-                
-            [k.key for k in paginator.paginate(Bucket=self.name, Delimiter="/", Prefix=prefix)['Contents']]
+            objects = []
+            for page in paginator.paginate(Bucket=self.name, Delimiter="/", Prefix=prefix):
+                for obj in page['Contents']:
+                    objects += obj.key
+            return objects
         return [k.key for k in self._boto_bucket.objects.all()]
 
     @property

--- a/bucketstore.py
+++ b/bucketstore.py
@@ -148,7 +148,8 @@ class S3Bucket:
         super(S3Bucket, self).__init__()
         self.name = name
         self.region = region or os.getenv("AWS_DEFAULT_REGION", AWS_DEFAULT_REGION)
-        self.endpoint_url = endpoint_url or os.getenv("AWS_ENDPOINT_URL", None)
+        env_endpoint_url = os.getenv("AWS_ENDPOINT_URL", "")
+        self.endpoint_url = endpoint_url or env_endpoint_url if env_endpoint_url else None
         self._boto_s3 = boto3.resource("s3", self.region, endpoint_url=self.endpoint_url)
         self._boto_bucket = self._boto_s3.Bucket(self.name)
 
@@ -267,7 +268,7 @@ def get(bucket_name: str, create: bool = False) -> S3Bucket:
 
 
 def login(
-    access_key_id: str, secret_access_key: str, region: str = AWS_DEFAULT_REGION, endpoint_url: str = None
+    access_key_id: str, secret_access_key: str, region: str = AWS_DEFAULT_REGION, endpoint_url: str = ""
 ) -> None:
     """sets environment variables for boto3."""
     os.environ["AWS_ACCESS_KEY_ID"] = access_key_id

--- a/bucketstore.py
+++ b/bucketstore.py
@@ -144,13 +144,23 @@ class S3Key:
 class S3Bucket:
     """An Amazon S3 Bucket."""
 
-    def __init__(self, name: str, create: bool = False, region: str = "", endpoint_url: str = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        create: bool = False,
+        region: str = "",
+        endpoint_url: str = None,
+    ) -> None:
         super(S3Bucket, self).__init__()
         self.name = name
         self.region = region or os.getenv("AWS_DEFAULT_REGION", AWS_DEFAULT_REGION)
         env_endpoint_url = os.getenv("AWS_ENDPOINT_URL", "")
-        self.endpoint_url = endpoint_url or env_endpoint_url if env_endpoint_url else None
-        self._boto_s3 = boto3.resource("s3", self.region, endpoint_url=self.endpoint_url)
+        self.endpoint_url = (
+            endpoint_url or env_endpoint_url if env_endpoint_url else None
+        )
+        self._boto_s3 = boto3.resource(
+            "s3", self.region, endpoint_url=self.endpoint_url
+        )
         self._boto_bucket = self._boto_s3.Bucket(self.name)
 
         # Check if the bucket exists.
@@ -188,15 +198,15 @@ class S3Bucket:
         """returns a list of keys in the bucket."""
         if prefix:
             if legacy_api:
-                paginator = self._boto_s3.meta.client.get_paginator('list_objects')
+                paginator = self._boto_s3.meta.client.get_paginator("list_objects")
             else:
-                paginator = self._boto_s3.meta.client.get_paginator('list_objects_v2')
+                paginator = self._boto_s3.meta.client.get_paginator("list_objects_v2")
             objects = []
             for page in paginator.paginate(Bucket=self.name, Prefix=prefix):
-                for obj in page.get('Contents', []):
-                    objects.append(obj['Key'])
+                for obj in page.get("Contents", []):
+                    objects.append(obj["Key"])
             return objects
-        
+
         return [k.key for k in self._boto_bucket.objects.all()]
 
     @property
@@ -268,7 +278,10 @@ def get(bucket_name: str, create: bool = False) -> S3Bucket:
 
 
 def login(
-    access_key_id: str, secret_access_key: str, region: str = AWS_DEFAULT_REGION, endpoint_url: str = ""
+    access_key_id: str,
+    secret_access_key: str,
+    region: str = AWS_DEFAULT_REGION,
+    endpoint_url: str = "",
 ) -> None:
     """sets environment variables for boto3."""
     os.environ["AWS_ACCESS_KEY_ID"] = access_key_id

--- a/bucketstore.py
+++ b/bucketstore.py
@@ -186,7 +186,7 @@ class S3Bucket:
     def list(self, prefix: str = None) -> List:
         """returns a list of keys in the bucket."""
         if prefix:
-            [k.key for k in self._boto_bucket.objects.filter(Prefix=prefix)]
+            [k.key for k in self._boto_bucket.objects.filter(Delimiter="/", Prefix=prefix)]
         return [k.key for k in self._boto_bucket.objects.all()]
 
     @property

--- a/bucketstore.py
+++ b/bucketstore.py
@@ -183,8 +183,10 @@ class S3Bucket:
                 return False
             raise  # pragma: no cover
 
-    def list(self) -> List:
+    def list(self, prefix: str = None) -> List:
         """returns a list of keys in the bucket."""
+        if prefix:
+            [k.key for k in self._boto_bucket.objects.filter(Prefix=prefix)]
         return [k.key for k in self._boto_bucket.objects.all()]
 
     @property

--- a/bucketstore.py
+++ b/bucketstore.py
@@ -144,11 +144,12 @@ class S3Key:
 class S3Bucket:
     """An Amazon S3 Bucket."""
 
-    def __init__(self, name: str, create: bool = False, region: str = "") -> None:
+    def __init__(self, name: str, create: bool = False, region: str = "", endpoint_url: str = None) -> None:
         super(S3Bucket, self).__init__()
         self.name = name
         self.region = region or os.getenv("AWS_DEFAULT_REGION", AWS_DEFAULT_REGION)
-        self._boto_s3 = boto3.resource("s3", self.region)
+        self.endpoint_url = endpoint_url or os.getenv("AWS_ENDPOINT_URL", None)
+        self._boto_s3 = boto3.resource("s3", self.region, endpoint_url=self.endpoint_url)
         self._boto_bucket = self._boto_s3.Bucket(self.name)
 
         # Check if the bucket exists.
@@ -255,9 +256,10 @@ def get(bucket_name: str, create: bool = False) -> S3Bucket:
 
 
 def login(
-    access_key_id: str, secret_access_key: str, region: str = AWS_DEFAULT_REGION
+    access_key_id: str, secret_access_key: str, region: str = AWS_DEFAULT_REGION, endpoint_url: str = None
 ) -> None:
     """sets environment variables for boto3."""
     os.environ["AWS_ACCESS_KEY_ID"] = access_key_id
     os.environ["AWS_SECRET_ACCESS_KEY"] = secret_access_key
     os.environ["AWS_DEFAULT_REGION"] = region
+    os.environ["AWS_ENDPOINT_URL"] = endpoint_url

--- a/bucketstore.py
+++ b/bucketstore.py
@@ -187,9 +187,9 @@ class S3Bucket:
         """returns a list of keys in the bucket."""
         if prefix:
             if legacy_api:
-                paginator = self._boto_s3.get_paginator('list_objects')
+                paginator = self._boto_s3.meta.client.get_paginator('list_objects')
             else:
-                paginator = self._boto_s3.get_paginator('list_objects_v2')
+                paginator = self._boto_s3.meta.client.get_paginator('list_objects_v2')
                 
             [k.key for k in paginator.paginate(Bucket=self.name, Delimiter="/", Prefix=prefix)['Contents']]
         return [k.key for k in self._boto_bucket.objects.all()]


### PR DESCRIPTION
Allow use of others s3 compatible object stores for example: Digital Ocean Spaces, Minio.
Tested with both.
