### PR TITLE
Fix mocking aws service

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ bucketstore pytest configuration
 import bucketstore
 import os
 import pytest
-from moto import mock_s3
+from moto import mock_aws
 from typing import Generator
 
 
@@ -24,7 +24,7 @@ def login() -> Generator:
 @pytest.fixture
 def bucket() -> Generator:
     """fixture that provides a bucketstore bucket."""
-    with mock_s3():
+    with mock_aws():
         yield bucketstore.get("bucketstore-playground", create=True)
 
 

--- a/tests/test_bucketstore.py
+++ b/tests/test_bucketstore.py
@@ -7,7 +7,7 @@ import os
 import pytest
 import sys
 import tempfile
-from moto import mock_s3
+from moto import mock_aws
 
 
 def dbg(text: str) -> None:
@@ -33,7 +33,7 @@ def test_login() -> None:
     assert os.environ["AWS_DEFAULT_REGION"] == "us-east-1"
 
 
-@mock_s3
+@mock_aws
 def test_buckets_can_be_created() -> None:
     bucket = bucketstore.get("test-bucket", create=True)
 
@@ -43,7 +43,7 @@ def test_buckets_can_be_created() -> None:
     assert "<S3Bucket" in repr(bucket)
 
 
-@mock_s3
+@mock_aws
 def test_buckets_are_not_created_automatically() -> None:
     with pytest.raises(ValueError):
         bucketstore.get("non-existent-bucket")


### PR DESCRIPTION
Since moto 5.x service specific mock decorator is removed. To fix this use `mock_aws` instead.